### PR TITLE
[taier-ui] remove the useless slash in publicURL

### DIFF
--- a/taier-ui/cup.config.js
+++ b/taier-ui/cup.config.js
@@ -6,7 +6,7 @@
  * > cup config // 按配置文件运行
  */
 
-const publicURL = 'http://schedule.dtstack.cn/';
+const publicURL = 'http://schedule.dtstack.cn';
 
 module.exports = {
 	name: 'taier',


### PR DESCRIPTION
因为target那边指定了端口