### PR TITLE
[fix_cluster][taier-ui]fix can't save when change tab in cluster

### DIFF
--- a/taier-ui/src/pages/console/cluster/newEdit/components/multiVerComp/index.tsx
+++ b/taier-ui/src/pages/console/cluster/newEdit/components/multiVerComp/index.tsx
@@ -217,6 +217,7 @@ export default function MultiVersionComp({
 			<Tabs
 				tabPosition="top"
 				className={`${className}__tabs`}
+				destroyInactiveTabPane
 				tabBarExtraContent={
 					<Dropdown
 						disabled={view}

--- a/taier-ui/src/pages/console/cluster/newEdit/index.tsx
+++ b/taier-ui/src/pages/console/cluster/newEdit/index.tsx
@@ -609,6 +609,7 @@ export default forwardRef((_, ref) => {
 										)
 									}
 									className="c-editCluster__container__componentTabs"
+									destroyInactiveTabPane
 									onChange={(tabActiveKey) => {
 										if (!isMultiVersion(Number(tabActiveKey))) {
 											getLoadTemplate(tabActiveKey);
@@ -653,6 +654,8 @@ export default forwardRef((_, ref) => {
 																preserve={false}
 																className="dt-cluster-content"
 																form={form}
+																labelCol={{ span: 24 }}
+																wrapperCol={{ span: 24 }}
 															>
 																<MultiVersionComp
 																	comp={comp}
@@ -689,6 +692,8 @@ export default forwardRef((_, ref) => {
 																		className="dt-cluster-content"
 																		scrollToFirstError
 																		form={form}
+																		labelCol={{ span: 24 }}
+																		wrapperCol={{ span: 24 }}
 																	>
 																		<FileConfig
 																			comp={vcomp}


### PR DESCRIPTION
### 简介
- 修复集群管理在某些情况下切换后无法保存的问题
- 优化集群管理文件配置栏样式问题

### 主要变更
- 切换 tab 后本应清空 form 的值，但是由于 tabPane 默认是持久化的，所以需要设置 `destroyInactiveTabPane` 在 tab 切换后将老的 tab 组件卸载



### Related Issues
Close #356 