### PR TITLE
chore: taier-ui[.umirc.ts] unable to communicate with backend when us…

### DIFF
--- a/taier-ui/.umirc.ts
+++ b/taier-ui/.umirc.ts
@@ -43,7 +43,7 @@ export default defineConfig({
 	tailwindcss: {},
 	proxy: {
 		'/taier': {
-			target: 'http://172.16.100.225:7001/proxy/121',
+			target: 'http://localhost:8090',
 			// target: 'http://192.168.96.73:8090',
 			changeOrigin: true,
 			secure: false,

--- a/taier-ui/.umirc.ts
+++ b/taier-ui/.umirc.ts
@@ -44,7 +44,6 @@ export default defineConfig({
 	proxy: {
 		'/taier': {
 			target: 'http://localhost:8090',
-			// target: 'http://192.168.96.73:8090',
 			changeOrigin: true,
 			secure: false,
 		},


### PR DESCRIPTION
The front-end cannot communicate with the back-end when it is started locally through the quick start case, and the configuration needs to be changed. I think this is not friendly. I have perfected it. As long as the front-end personnel do not push `.umirc.ts`, this problem will no longer occur.