### PR TITLE
[chore_tenant_check][Taier-all] The back-end checks the regular expre…

### DIFF
--- a/taier-common/src/main/java/com/dtstack/taier/common/constant/PatternConstant.java
+++ b/taier-common/src/main/java/com/dtstack/taier/common/constant/PatternConstant.java
@@ -7,4 +7,11 @@ public interface PatternConstant {
 
     /** 字符串查找是否存在密码字段的正则表达式 **/
 	String PASSWORD_FIELD_REGEX = "\"(pass(word)?|accesskey)\"\\s*:\\s*\"\\*{6}\"";
+
+	/**
+	 * 正则: 租户名称正则表达式,字母、数字、下划线组成，且长度不超过64个字符
+	 * Regular: Tenant name regular expression, consisting of letters, numbers, and underscores, and the length does not exceed 64 characters
+	 */
+	String TENANT_NAME_REGEX = "^[a-zA-Z0-9_]{1,64}$";
+
 }

--- a/taier-common/src/main/java/com/dtstack/taier/common/exception/ErrorCode.java
+++ b/taier-common/src/main/java/com/dtstack/taier/common/exception/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode implements ExceptionEnums, Serializable {
     CATALOGUE_EXISTS(146, "this catalogue exist","目录已存在"),
     CATALOGUE_INIT_FAILED(147, "init catalogue failed","初始化目录失败"),
     CATALOGUE_FUNCTION_MANAGE_UN_INIT(148, "function manage catalogue un init","函数管理未初始化"),
+    TENANT_NAME_VERIFICATION_ERROR(149, "tenant name verification error","租户名称只能由字母、数字、下划线组成，且长度不超过64个字符"),
 
 
 

--- a/taier-common/src/main/java/com/dtstack/taier/common/util/RegexUtils.java
+++ b/taier-common/src/main/java/com/dtstack/taier/common/util/RegexUtils.java
@@ -1,0 +1,41 @@
+package com.dtstack.taier.common.util;
+
+import java.util.regex.Pattern;
+
+import static com.dtstack.taier.common.constant.PatternConstant.*;
+
+/**
+ * 正则表达式校验工具
+ * Regular expression check utils
+ *
+ * @author bnyte
+ * @date 2022/5/2 16:03
+ */
+public class RegexUtils {
+
+    /**
+     * 校验租户名称
+     * @param input 要检查的字符串
+     *              string to check
+     * @return TRUE: 校验通过, FALSE: 校验不通过
+     *         TRUE: verification passed, FALSE: verification failed
+     */
+    public static boolean tenantName(String input) {
+        return matches(input, TENANT_NAME_REGEX);
+    }
+
+    /**
+     * 正则表达式公共方法
+     * regular expression public methods
+     * @param input 要检查的字符串
+     *              string to check
+     * @param regex 正则表达式
+     *              regular expression
+     * @return TRUE: 校验通过, FALSE: 校验不通过
+     *         TRUE: verification passed, FALSE: verification failed
+     */
+    private static boolean matches(String input, String regex) {
+        return Pattern.matches(regex, input);
+    }
+
+}

--- a/taier-data-develop/src/main/java/com/dtstack/taier/develop/controller/console/TenantController.java
+++ b/taier-data-develop/src/main/java/com/dtstack/taier/develop/controller/console/TenantController.java
@@ -105,13 +105,6 @@ public class TenantController {
 
     @PostMapping(value = "/addTenant")
     public R<Void> addTenant(@RequestParam("tenantName") String tenantName, @CookieValue(Cookies.USER_ID) Long userId) throws Exception {
-        if(StringUtils.isBlank(tenantName)){
-            throw new RdosDefineException(ErrorCode.INVALID_PARAMETERS);
-        }
-        Tenant tenant = tenantService.findByName(tenantName.trim());
-        if(null != tenant){
-            throw new RdosDefineException("tenant has exist");
-        }
         tenantService.addTenant(tenantName,userId);
         return R.empty();
     }

--- a/taier-data-develop/src/main/java/com/dtstack/taier/develop/service/console/TenantService.java
+++ b/taier-data-develop/src/main/java/com/dtstack/taier/develop/service/console/TenantService.java
@@ -24,6 +24,7 @@ import com.dtstack.taier.common.enums.Deleted;
 import com.dtstack.taier.common.enums.EComponentType;
 import com.dtstack.taier.common.exception.ErrorCode;
 import com.dtstack.taier.common.exception.RdosDefineException;
+import com.dtstack.taier.common.util.RegexUtils;
 import com.dtstack.taier.dao.domain.ClusterTenant;
 import com.dtstack.taier.dao.domain.Component;
 import com.dtstack.taier.dao.domain.Queue;
@@ -51,6 +52,7 @@ import com.dtstack.taier.scheduler.service.ClusterService;
 import com.dtstack.taier.scheduler.service.ComponentService;
 import com.dtstack.taier.scheduler.vo.ComponentVO;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -252,11 +254,24 @@ public class TenantService {
     }
 
     public void addTenant(String tenantName, Long createUserId) {
+        // pre check
+        preCheckForAddTenant(tenantName);
         Tenant tenant = new Tenant();
         tenant.setTenantName(tenantName);
         tenant.setCreateUserId(createUserId);
         tenant.setGmtCreate(Timestamp.from(Instant.now()));
         tenantMapper.insert(tenant);
+    }
+
+    private void preCheckForAddTenant(String tenantName) {
+        if(StringUtils.isBlank(tenantName)){
+            throw new RdosDefineException(ErrorCode.INVALID_PARAMETERS);
+        }
+        if (!RegexUtils.tenantName(tenantName)) throw new RdosDefineException(ErrorCode.TENANT_NAME_VERIFICATION_ERROR);
+        Tenant tenant = findByName(tenantName.trim());
+        if(null != tenant){
+            throw new RdosDefineException("tenant has exist");
+        }
     }
 
     @Transactional(rollbackFor = Exception.class)


### PR DESCRIPTION
- `taier-data-develop`模块在接口`/taier/tenant/addTenant`针对创建租户名称时添加后端租户名称正则规范校验
- `taier-common`模块在接口类`com.dtstack.taier.common.constant.PatternConstant`中添加租户名称正则表达式
- `taier-common`模块在包`com.dtstack.taier.common.util`添加正则工具类`RegexUtils`提供正则表达式公共方法
- `taier-common`模块在枚举类`com.dtstack.taier.common.exception.ErrorCode`中添加租户名称正则表达校验失败响应code