### PR TITLE
[fix_task][taier-ui]fix can't filter periodType in task operation

### DIFF
--- a/taier-ui/src/pages/operation/task.tsx
+++ b/taier-ui/src/pages/operation/task.tsx
@@ -110,7 +110,7 @@ export default () => {
 			currentPage: current,
 			pageSize,
 			taskTypeList: filters.taskType || [],
-			periodTypeList: filters.taskPeriodId || [],
+			periodTypeList: filters.periodType || [],
 			...requestParams,
 		});
 		if (res.code === 1) {


### PR DESCRIPTION
### 简介
- 修复运维中心任务列表调度周期筛选无效的问题


### Related  Issues
#436 