### PR TITLE
[issue_466][taier-ui]fix folderTree

### DIFF
--- a/taier-ui/src/components/dataSync/index.tsx
+++ b/taier-ui/src/components/dataSync/index.tsx
@@ -295,7 +295,16 @@ function DataSync({ current }: molecule.model.IEditor) {
 	};
 
 	const handleSaveTab = () => {
-		saveTask();
+		saveTask()
+			.then((res) => res?.data?.id)
+			.then((id) => {
+				if (id !== undefined) {
+					molecule.editor.updateTab({
+						id: current!.tab!.id,
+						status: undefined,
+					});
+				}
+			});
 	};
 
 	// 获取当前任务的数据

--- a/taier-ui/src/components/folderPicker/index.tsx
+++ b/taier-ui/src/components/folderPicker/index.tsx
@@ -26,7 +26,7 @@ import molecule from '@dtinsight/molecule';
 import resourceManagerTree from '@/services/resourceManagerService';
 import functionManagerService from '@/services/functionManagerService';
 import type { TreeSelectProps } from 'antd/lib/tree-select';
-import { loadTreeNode } from '@/utils/extensions';
+import { catalogueService } from '@/services';
 
 interface FolderPickerProps extends CustomTreeSelectProps {
 	dataType: CATELOGUE_TYPE;
@@ -35,9 +35,12 @@ interface FolderPickerProps extends CustomTreeSelectProps {
 export default function FolderPicker(props: FolderPickerProps) {
 	const [flag, rerender] = useState(false);
 	const loadDataAsync: TreeSelectProps['loadData'] = async (treeNode) => {
-		const currentData = treeNode.props.dataRef.data;
+		const currentData = treeNode.props.dataRef;
 		if (!currentData.children?.length) {
-			await loadTreeNode(currentData, props.dataType);
+			await catalogueService.loadTreeNode(
+				{ id: currentData?.data?.id, catalogueType: currentData?.data?.catalogueType },
+				props.dataType,
+			);
 			rerender((f) => !f);
 		}
 	};

--- a/taier-ui/src/components/task/editFolder.tsx
+++ b/taier-ui/src/components/task/editFolder.tsx
@@ -99,10 +99,11 @@ export default connect(
 						rules={[
 							{
 								max: 64,
-								message: '任务名称不得超过20个字符！',
+								message: '目录名称不得超过64个字符！',
 							},
 							{
 								required: true,
+								message: '文件夹名称不能为空',
 							},
 						]}
 					>

--- a/taier-ui/src/constant/index.ts
+++ b/taier-ui/src/constant/index.ts
@@ -24,6 +24,10 @@ import type { ISubMenuProps } from '@dtinsight/molecule/esm/components';
  */
 export enum ID_COLLECTIONS {
 	/**
+	 * 创建任务
+	 */
+	TASK_CREATE_ID = 'task.create',
+	/**
 	 * 任务运行按钮
 	 */
 	TASK_RUN_ID = 'task.run',

--- a/taier-ui/src/extensions/catalogue/index.ts
+++ b/taier-ui/src/extensions/catalogue/index.ts
@@ -16,68 +16,9 @@
  * limitations under the License.
  */
 
-import { CATELOGUE_TYPE } from '@/constant';
-import functionManagerService from '@/services/functionManagerService';
-import resourceManagerService from '@/services/resourceManagerService';
-import { transformCatalogueToTree, loadTreeNode, getCatalogueViaNode } from '@/utils/extensions';
-import molecule from '@dtinsight/molecule';
 import type { UniqueId } from '@dtinsight/molecule/esm/common/types';
 import type { IExtension } from '@dtinsight/molecule/esm/model';
-import { getRootFolderViaSource } from '@/utils';
-
-/**
- * 获取根目录
- */
-export function getCatalogueTree() {
-	getCatalogueViaNode({ id: 0 }).then(async (res) => {
-		if (!res) return;
-		const { children } = res;
-		if (!children) return;
-
-		const taskData = getRootFolderViaSource(children, CATELOGUE_TYPE.TASK);
-		const resourceData = getRootFolderViaSource(children, CATELOGUE_TYPE.RESOURCE);
-		const funcData = getRootFolderViaSource(children, CATELOGUE_TYPE.FUNCTION);
-
-		// 资源根目录
-		if (resourceData) {
-			const resourceRoot = resourceData;
-			const resourceNode = transformCatalogueToTree(
-				resourceRoot,
-				CATELOGUE_TYPE.RESOURCE,
-				true,
-			)!;
-			resourceManagerService.add(resourceNode);
-		}
-
-		// 函数根目录
-		if (funcData) {
-			const funcRoot = funcData;
-			const functionNode = transformCatalogueToTree(funcRoot, CATELOGUE_TYPE.FUNCTION, true)!;
-			functionManagerService.add(functionNode);
-
-			// sql 节点必存在 catalogueType，对所有的节点都求一遍子树
-			const SqlNodes = funcRoot?.children?.filter((child: any) => child.catalogueType) || [];
-			SqlNodes.forEach((sqlNode) => {
-				loadTreeNode(sqlNode, CATELOGUE_TYPE.FUNCTION);
-			});
-		}
-
-		// 任务开发根目录
-		if (taskData) {
-			const taskRootFolder = taskData?.children?.[0];
-			if (taskRootFolder) {
-				const taskNode = transformCatalogueToTree(
-					taskRootFolder,
-					CATELOGUE_TYPE.TASK,
-					true,
-				)!;
-
-				molecule.folderTree.add(taskNode);
-				loadTreeNode(taskRootFolder, CATELOGUE_TYPE.TASK);
-			}
-		}
-	});
-}
+import { catalogueService } from '@/services';
 
 /**
  * This is for getting the root catalogues including the resouces and tasks and functions
@@ -86,7 +27,7 @@ export default class CatalogueExtension implements IExtension {
 	id: UniqueId = 'Catalogue';
 	name: string = 'Catalogue';
 	activate(): void {
-		getCatalogueTree();
+		catalogueService.loadRootFolder();
 	}
 	dispose(): void {
 		throw new Error('Method not implemented.');

--- a/taier-ui/src/pages/console/resource.tsx
+++ b/taier-ui/src/pages/console/resource.tsx
@@ -27,7 +27,7 @@ import Resource from './resourceView';
 import BindTenant from './bindTenant';
 import type { IClusterProps } from '@/components/bindCommModal';
 import type { ITableProps } from './bindTenant';
-import { getCatalogueTree } from '@/extensions/catalogue';
+import { catalogueService } from '@/services';
 import './resource.scss';
 
 const FormItem = Form.Item;
@@ -125,7 +125,7 @@ export default () => {
 			// 刷新租户列表
 			bindTenantRef.current?.getTenant();
 			// 刷新目录树
-			getCatalogueTree();
+			catalogueService.loadRootFolder();
 			// 刷新资源管理
 			getClusterList();
 		}

--- a/taier-ui/src/pages/function/index.tsx
+++ b/taier-ui/src/pages/function/index.tsx
@@ -18,11 +18,12 @@
 
 import React, { useState } from 'react';
 import type { IMenuItemProps, ITreeNodeItemProps } from '@dtinsight/molecule/esm/components';
+import { catalogueService } from '@/services';
 import { ActionBar } from '@dtinsight/molecule/esm/components';
 import { Content, Header } from '@dtinsight/molecule/esm/workbench/sidebar';
 import { connect } from '@dtinsight/molecule/esm/react';
 import functionManagerService from '../../services/functionManagerService';
-import type { IFolderTree, IFolderTreeNodeProps } from '@dtinsight/molecule/esm/model';
+import type { IFolderTree } from '@dtinsight/molecule/esm/model';
 import { FolderTree } from '@dtinsight/molecule/esm/workbench/sidebar/explore';
 import { Modal } from 'antd';
 import ajax from '../../api';
@@ -35,7 +36,6 @@ import {
 	MENU_TYPE_ENUM,
 	TASK_TYPE_ENUM,
 } from '@/constant';
-import { loadTreeNode } from '@/utils/extensions';
 import { TreeViewUtil } from '@dtinsight/molecule/esm/common/treeUtil';
 import type { UniqueId } from '@dtinsight/molecule/esm/common/types';
 import { DetailInfoModal } from '@/components/detailInfo';
@@ -87,11 +87,7 @@ const FunctionManagerView = ({ headerToolBar, panel, entry }: IFunctionViewProps
 	const [expandKeys, setExpandKeys] = useState<string[]>([]);
 
 	const updateNodePid = async (node: ITreeNodeItemProps) => {
-		loadTreeNode(node.data, CATELOGUE_TYPE.FUNCTION);
-	};
-
-	const loadData = async (treeNode: IFolderTreeNodeProps) => {
-		updateNodePid(treeNode);
+		catalogueService.loadTreeNode(node.data, CATELOGUE_TYPE.FUNCTION);
 	};
 
 	const handleSelect = (file?: ITreeNodeItemProps) => {
@@ -358,7 +354,7 @@ const FunctionManagerView = ({ headerToolBar, panel, entry }: IFunctionViewProps
 						onRightClick={handleRightClick}
 						draggable={false}
 						onSelectFile={handleSelect}
-						onLoadData={loadData}
+						onLoadData={updateNodePid}
 						onClickContextMenu={handleContextMenu}
 						panel={panel}
 						entry={entry}

--- a/taier-ui/src/pages/resource/index.tsx
+++ b/taier-ui/src/pages/resource/index.tsx
@@ -26,10 +26,10 @@ import type {
 	ITreeNodeItemProps,
 } from '@dtinsight/molecule/esm/components';
 import { ActionBar } from '@dtinsight/molecule/esm/components';
-import type { IFolderTree, IFolderTreeNodeProps } from '@dtinsight/molecule/esm/model';
+import type { IFolderTree } from '@dtinsight/molecule/esm/model';
 import { FileTypes } from '@dtinsight/molecule/esm/model';
 import { connect } from '@dtinsight/molecule/esm/react';
-import { loadTreeNode } from '@/utils/extensions';
+import { catalogueService } from '@/services';
 import { CATELOGUE_TYPE, ID_COLLECTIONS, RESOURCE_ACTIONS } from '@/constant';
 import resourceManagerTree from '../../services/resourceManagerService';
 import type { IFormFieldProps } from './resModal';
@@ -71,7 +71,7 @@ export default ({ panel, headerToolBar, entry }: IResourceViewProps & IFolderTre
 	>(undefined);
 
 	const updateNodePid = async (node: ITreeNodeItemProps) => {
-		loadTreeNode(node.data, CATELOGUE_TYPE.RESOURCE);
+		catalogueService.loadTreeNode(node.data, CATELOGUE_TYPE.RESOURCE);
 	};
 
 	const handleUpload = () => {
@@ -229,10 +229,6 @@ export default ({ panel, headerToolBar, entry }: IResourceViewProps & IFolderTre
 		}
 	};
 
-	const loadData = async (treeNode: IFolderTreeNodeProps) => {
-		loadTreeNode(treeNode.data, CATELOGUE_TYPE.RESOURCE);
-	};
-
 	const handleSelect = (file?: ITreeNodeItemProps) => {
 		resourceManagerTree.setActive(file?.id);
 		if (file) {
@@ -348,7 +344,7 @@ export default ({ panel, headerToolBar, entry }: IResourceViewProps & IFolderTre
 						onRightClick={handleRightClick}
 						draggable={false}
 						onSelectFile={handleSelect}
-						onLoadData={loadData}
+						onLoadData={updateNodePid}
 						onClickContextMenu={handleContextMenu}
 						entry={entry}
 						panel={panel}
@@ -375,7 +371,7 @@ export default ({ panel, headerToolBar, entry }: IResourceViewProps & IFolderTre
 				dataType={CATELOGUE_TYPE.RESOURCE}
 				isModalShow={folderVisible}
 				toggleCreateFolder={handleCloseFolderModal}
-				treeData={resourceManagerTree.getState().folderTree?.data?.[0]?.children?.[0].data}
+				treeData={catalogueService.getRootFolder(CATELOGUE_TYPE.RESOURCE)?.data}
 				defaultData={folderData}
 				addOfflineCatalogue={handleAddCatalogue}
 				editOfflineCatalogue={handleEditCatalogue}

--- a/taier-ui/src/pages/resource/resModal.tsx
+++ b/taier-ui/src/pages/resource/resModal.tsx
@@ -23,14 +23,8 @@ import { CATELOGUE_TYPE, formItemLayout, RESOURCE_TYPE } from '@/constant';
 import type { CatalogueDataProps } from '@/interface';
 import { IComputeType } from '@/interface';
 import type { RcFile } from 'antd/lib/upload';
-import resourceManagerTree from '@/services/resourceManagerService';
 import { resourceNameMapping } from '@/utils/enums';
-
-export function getContainer(id: string) {
-	const container = document.createElement('div');
-	document.getElementById(id)?.appendChild(container);
-	return container;
-}
+import { catalogueService } from '@/services';
 
 const FormItem = Form.Item;
 const { Option } = Select;
@@ -128,7 +122,7 @@ export default function ResModal({
 			});
 		};
 
-		const treeData = resourceManagerTree.getState().folderTree?.data?.[0]?.children?.[0];
+		const treeData = catalogueService.getRootFolder(CATELOGUE_TYPE.RESOURCE);
 		if (treeData) {
 			loop([treeData.data]);
 		}
@@ -274,7 +268,7 @@ export default function ResModal({
 							},
 						]}
 						initialValue={
-							resourceManagerTree.getState().folderTree?.data?.[0]?.children?.[0]?.id
+							catalogueService.getRootFolder(CATELOGUE_TYPE.RESOURCE)?.data?.id
 						}
 					>
 						<FolderPicker dataType={CATELOGUE_TYPE.RESOURCE} showFile={false} />
@@ -309,9 +303,7 @@ export default function ResModal({
 							validator: checkNotDir,
 						},
 					]}
-					initialValue={
-						resourceManagerTree.getState().folderTree?.data?.[0]?.children?.[0]?.id
-					}
+					initialValue={catalogueService.getRootFolder(CATELOGUE_TYPE.RESOURCE)?.data?.id}
 				>
 					<FolderPicker dataType={CATELOGUE_TYPE.RESOURCE} showFile />
 				</FormItem>

--- a/taier-ui/src/services/breadcrumbService.ts
+++ b/taier-ui/src/services/breadcrumbService.ts
@@ -1,0 +1,52 @@
+import { CATELOGUE_TYPE } from '@/constant';
+import { TreeViewUtil } from '@dtinsight/molecule/esm/common/treeUtil';
+import type molecule from '@dtinsight/molecule';
+import type { UniqueId } from '@dtinsight/molecule/esm/common/types';
+import type { IBreadcrumbItemProps } from '@dtinsight/molecule/esm/components';
+import { catalogueService } from '.';
+
+interface IBreadcrumbService {
+	/**
+	 * 根据目录树 id 获取父节点并生成面包屑
+	 */
+	getBreadcrumb: (id: UniqueId) => IBreadcrumbItemProps[];
+}
+
+export default class BreadcrumbService implements IBreadcrumbService {
+	private hashTree: TreeViewUtil<molecule.model.IFolderTreeNodeProps> | null = null;
+	constructor() {
+		catalogueService.onUpdate(() => {
+			this.updateTree();
+		});
+	}
+
+	private updateTree = () => {
+		const root = catalogueService.getRootFolder(CATELOGUE_TYPE.TASK);
+		if (root) {
+			this.hashTree = new TreeViewUtil<molecule.model.IFolderTreeNodeProps>(root);
+		}
+	};
+
+	public getBreadcrumb = (id: UniqueId) => {
+		if (this.hashTree) {
+			const stack = [this.hashTree.getHashMap(id)];
+			const res: IBreadcrumbItemProps[] = [];
+			while (stack.length) {
+				const hash = stack.pop();
+				if (hash) {
+					res.push({
+						id: hash.node.id,
+						name: hash.node.name,
+					});
+
+					if (hash.parent) {
+						stack.push(this.hashTree.getHashMap(hash.parent));
+					}
+				}
+			}
+
+			return res.reverse();
+		}
+		return [];
+	};
+}

--- a/taier-ui/src/services/catalogueService.ts
+++ b/taier-ui/src/services/catalogueService.ts
@@ -1,0 +1,279 @@
+import api from '@/api';
+import { CATELOGUE_TYPE, MENU_TYPE_ENUM } from '@/constant';
+import type { CatalogueDataProps } from '@/interface';
+import { getTenantId, getUserId } from '@/utils';
+import { fileIcon } from '@/utils/extensions';
+import molecule from '@dtinsight/molecule';
+import { GlobalEvent } from '@dtinsight/molecule/esm/common/event';
+import { FileTypes, TreeNodeModel } from '@dtinsight/molecule/esm/model';
+import { singleton } from 'tsyringe';
+import functionManagerService from './functionManagerService';
+import resourceManagerService from './resourceManagerService';
+
+interface ICatalogueService {
+	/**
+	 * 加载目录树的根目录
+	 */
+	loadRootFolder: () => void;
+	/**
+	 * 获取目录树的根目录
+	 */
+	getRootFolder: (source: CATELOGUE_TYPE) => molecule.model.IFolderTreeNodeProps | undefined;
+	/**
+	 * 获取目录树的子节点
+	 * @param node 更新当前 Node 节点的子节点，不改变 Node 节点
+	 */
+	loadTreeNode: (
+		node: Partial<Pick<CatalogueDataProps, 'id' | 'catalogueType'>>,
+		source: CATELOGUE_TYPE,
+	) => void;
+	/**
+	 * 目录树更新监听事件
+	 */
+	onUpdate: (callback: () => void) => void;
+}
+
+export enum CatalogueEventKind {
+	onUpdate = 'catalogue.update',
+}
+
+@singleton()
+export default class CatalogueService extends GlobalEvent implements ICatalogueService {
+	/**
+	 * 异步加载目录树节点
+	 */
+	private getCatalogueViaNode = async (
+		node: Partial<Pick<CatalogueDataProps, 'id' | 'catalogueType'>>,
+	): Promise<CatalogueDataProps | undefined> => {
+		if (!node) throw new Error('[getCatalogueViaNode]: failed to get catelogue');
+		const res = await api.getOfflineCatalogue({
+			isGetFile: true,
+			nodePid: node.id,
+			catalogueType: node.catalogueType,
+			userId: getUserId(),
+			tenantId: getTenantId(),
+		});
+		if (res.code === 1) {
+			return res.data;
+		}
+		return undefined;
+	};
+
+	private getRootFolderViaSource = (data: CatalogueDataProps[], source: CATELOGUE_TYPE) => {
+		switch (source) {
+			case CATELOGUE_TYPE.TASK: {
+				return data.find((item) => item.catalogueType === MENU_TYPE_ENUM.TASK);
+			}
+
+			case CATELOGUE_TYPE.RESOURCE: {
+				return data.find((item) => item.catalogueType === MENU_TYPE_ENUM.RESOURCE);
+			}
+
+			case CATELOGUE_TYPE.FUNCTION: {
+				return data.find((item) => item.catalogueType === MENU_TYPE_ENUM.FUNCTION);
+			}
+			default:
+				return undefined;
+		}
+	};
+
+	/**
+	 * Only transform current catalogue to treeNodeModel, ignore children
+	 */
+	private transformCatalogueToTree = (
+		catalogue: CatalogueDataProps | undefined,
+		source: CATELOGUE_TYPE,
+	) => {
+		if (!catalogue) return;
+		const folderType = ['folder', 'catalogue'];
+		switch (source) {
+			case CATELOGUE_TYPE.RESOURCE: {
+				const fileType = folderType.includes(catalogue.type)
+					? FileTypes.Folder
+					: FileTypes.File;
+
+				return new TreeNodeModel({
+					// prevent same id between folder and file
+					id: fileType === FileTypes.File ? catalogue.id : `${catalogue.id}-folder`,
+					name: catalogue.name,
+					fileType,
+					icon: fileIcon(catalogue.resourceType, source),
+					isLeaf: fileType === FileTypes.File,
+					data: catalogue,
+					children: [],
+				});
+			}
+
+			case CATELOGUE_TYPE.FUNCTION: {
+				const { id, type, name } = catalogue;
+				const fileType = folderType.includes(type) ? FileTypes.Folder : FileTypes.File;
+				// Because of the same id in different levels, so we should set another uniq id for each tree node
+				return new TreeNodeModel({
+					id: `${id}-${folderType.includes(type) ? 'folder' : 'file'}`,
+					name,
+					location: name,
+					fileType,
+					isLeaf: fileType === FileTypes.File,
+					data: catalogue,
+					icon: fileIcon(catalogue.taskType, source),
+					children: [],
+				});
+			}
+
+			case CATELOGUE_TYPE.TASK: {
+				const fileType = folderType.includes(catalogue.type)
+					? FileTypes.Folder
+					: FileTypes.File;
+
+				// prevent same id between folder and file
+				const id = fileType === FileTypes.File ? catalogue.id : `${catalogue.id}-folder`;
+				return new TreeNodeModel({
+					id,
+					name: catalogue.name,
+					location: catalogue.name,
+					fileType,
+					icon: fileIcon(catalogue.taskType, source),
+					isLeaf: fileType === FileTypes.File,
+					data: catalogue,
+					children: molecule.folderTree.get(id)?.children || [],
+				});
+			}
+
+			default:
+				return undefined;
+		}
+	};
+
+	private getServiceBySource = (source: CATELOGUE_TYPE) => {
+		switch (source) {
+			case CATELOGUE_TYPE.TASK:
+				return molecule.folderTree;
+			case CATELOGUE_TYPE.FUNCTION:
+				return functionManagerService;
+			case CATELOGUE_TYPE.RESOURCE:
+				return resourceManagerService;
+			default:
+				return null;
+		}
+	};
+
+	/**
+	 * @param node 更新当前 Node 节点的子节点，不改变 Node 节点
+	 */
+	public loadTreeNode = async (
+		node: Partial<Pick<CatalogueDataProps, 'id' | 'catalogueType'>>,
+		source: CATELOGUE_TYPE,
+	) => {
+		const data = await this.getCatalogueViaNode(node);
+		if (data) {
+			const childrenNodes = <molecule.model.TreeNodeModel[]>(
+				(
+					data?.children?.map((child) => this.transformCatalogueToTree(child, source)) ||
+					[]
+				).filter(Boolean)
+			);
+			const service = this.getServiceBySource(source);
+			const treeNode = service?.get(`${node.id!}-folder`);
+			if (treeNode) {
+				service?.update({
+					...treeNode,
+					children: childrenNodes,
+				});
+
+				this.emit(CatalogueEventKind.onUpdate);
+				return service?.get(treeNode.id);
+			}
+		}
+	};
+
+	public getRootFolder = (source: CATELOGUE_TYPE) => {
+		const service = this.getServiceBySource(source);
+		if (source === CATELOGUE_TYPE.TASK) {
+			return service?.getState().folderTree?.data?.[0];
+		}
+		return service?.getState().folderTree?.data?.[0]?.children?.[0];
+	};
+
+	public loadRootFolder = () => {
+		this.getCatalogueViaNode({ id: 0 }).then((res) => {
+			if (!res || !res.children) {
+				return;
+			}
+			const { children } = res;
+
+			const taskData = this.getRootFolderViaSource(children, CATELOGUE_TYPE.TASK);
+			const resourceData = this.getRootFolderViaSource(children, CATELOGUE_TYPE.RESOURCE);
+			const funcData = this.getRootFolderViaSource(children, CATELOGUE_TYPE.FUNCTION);
+
+			// 更新资源目录树
+			if (resourceData) {
+				const resourceRoot = resourceData;
+				const resourceNode = this.transformCatalogueToTree(
+					resourceRoot,
+					CATELOGUE_TYPE.RESOURCE,
+				)!;
+				const childrenNodes =
+					resourceRoot.children?.map(
+						(child) => this.transformCatalogueToTree(child, CATELOGUE_TYPE.RESOURCE)!,
+					) || [];
+
+				// set a root folder
+				resourceNode.fileType = FileTypes.RootFolder;
+				// put children to root folder
+				resourceNode.children = childrenNodes;
+				resourceManagerService.add(resourceNode);
+			}
+
+			// 更新函数目录树
+			if (funcData) {
+				const funcRoot = funcData;
+				const functionNode = this.transformCatalogueToTree(
+					funcRoot,
+					CATELOGUE_TYPE.FUNCTION,
+				)!;
+				const childrenNodes =
+					funcRoot.children
+						// there is a system function in the children node of root folder, we'd better to filter it
+						?.filter((child) => child.name !== '系统函数')
+						.map(
+							(child) =>
+								this.transformCatalogueToTree(child, CATELOGUE_TYPE.FUNCTION)!,
+						) || [];
+
+				// set a root folder
+				functionNode.fileType = FileTypes.RootFolder;
+				// put children to root folder
+				functionNode.children = childrenNodes;
+				functionManagerService.add(functionNode);
+
+				// // sql 节点必存在 catalogueType，对所有的节点都求一遍子树
+				// const SqlNodes =
+				// 	funcRoot?.children?.filter((child: any) => child.catalogueType) || [];
+				// SqlNodes.forEach((sqlNode) => {
+				// 	loadTreeNode(sqlNode, CATELOGUE_TYPE.FUNCTION);
+				// });
+			}
+
+			// 任务开发根目录
+			if (taskData) {
+				const taskRootFolder = taskData?.children?.[0];
+				if (taskRootFolder) {
+					const taskNode = this.transformCatalogueToTree(
+						taskRootFolder,
+						CATELOGUE_TYPE.TASK,
+					)!;
+
+					taskNode.fileType = FileTypes.RootFolder;
+					molecule.folderTree.add(taskNode);
+
+					// 获取当前根目录的下级目录，确保打开 Explorer 有数据展示
+					this.loadTreeNode(taskRootFolder, CATELOGUE_TYPE.TASK);
+				}
+			}
+		});
+	};
+
+	public onUpdate = (callback: () => void) => {
+		this.subscribe(CatalogueEventKind.onUpdate, callback);
+	};
+}

--- a/taier-ui/src/services/index.ts
+++ b/taier-ui/src/services/index.ts
@@ -1,8 +1,12 @@
 import { container } from 'tsyringe';
 import EditorActionBarService from './editorActionBarService';
 import ExecuteService from './executeService';
+import CatalogueService from './catalogueService';
+import BreadcrumbService from './breadcrumbService';
 
 const editorActionBarService = container.resolve(EditorActionBarService);
 const executeService = container.resolve(ExecuteService);
+const catalogueService = container.resolve(CatalogueService);
+const breadcrumbService = container.resolve(BreadcrumbService);
 
-export { editorActionBarService, executeService };
+export { editorActionBarService, catalogueService, executeService, breadcrumbService };

--- a/taier-ui/src/utils/extensions.tsx
+++ b/taier-ui/src/utils/extensions.tsx
@@ -17,9 +17,7 @@
  */
 
 import molecule from '@dtinsight/molecule/esm';
-import { message } from 'antd';
 import type { IFolderTreeNodeProps } from '@dtinsight/molecule/esm/model';
-import { FileTypes, TreeNodeModel } from '@dtinsight/molecule/esm/model';
 import {
 	FlinkSQLIcon,
 	SyntaxIcon,
@@ -28,9 +26,6 @@ import {
 	ResourceIcon,
 	DataCollectionIcon,
 } from '@/components/icon';
-import api from '@/api';
-import functionManagerService from '@/services/functionManagerService';
-import resourceManagerTree from '@/services/resourceManagerService';
 import type { RESOURCE_TYPE } from '@/constant';
 import { ID_COLLECTIONS } from '@/constant';
 import { CATELOGUE_TYPE, TASK_TYPE_ENUM } from '@/constant';
@@ -38,17 +33,10 @@ import type { CatalogueDataProps, IOfflineTaskProps } from '@/interface';
 import { executeService } from '@/services';
 import taskResultService, { createLog } from '@/services/taskResultService';
 import Result from '@/components/task/result';
-import { filterSql, getTenantId, getUserId } from '.';
+import { filterSql } from '.';
 import stream from '@/api/stream';
 import { TreeViewUtil } from '@dtinsight/molecule/esm/common/treeUtil';
 import { transformTabDataToParams } from './saveTask';
-
-export function resetEditorGroup() {
-	molecule.editor.updateActions([
-		{ id: ID_COLLECTIONS.TASK_RUN_ID, disabled: true },
-		{ id: ID_COLLECTIONS.TASK_STOP_ID, disabled: true },
-	]);
-}
 
 /**
  * 根据不同任务渲染不同的图标
@@ -81,174 +69,6 @@ export function fileIcon(
 		default:
 			return 'code';
 	}
-}
-
-/**
- * 异步加载树结点
- * @param node
- * @returns
- */
-export async function getCatalogueViaNode(
-	node: Partial<CatalogueDataProps>,
-): Promise<CatalogueDataProps | undefined> {
-	if (!node) throw new Error('[getCatalogueViaNode]: failed to get catelogue');
-	const res = await api.getOfflineCatalogue({
-		isGetFile: true,
-		nodePid: node.id,
-		catalogueType: node.catalogueType,
-		userId: getUserId(),
-		tenantId: getTenantId(),
-	});
-	if (res.code === 1) {
-		return res.data;
-	}
-	return undefined;
-}
-
-/**
- * Transform the catalogue data from back-end to the tree structure
- * @param catalogue
- * @param source
- * @returns
- */
-export function transformCatalogueToTree(
-	catalogue: CatalogueDataProps | undefined,
-	source: CATELOGUE_TYPE,
-	isRootFolder: boolean = false,
-): TreeNodeModel | undefined {
-	const folderType = ['folder', 'catalogue'];
-	if (!catalogue) return;
-	switch (source) {
-		case CATELOGUE_TYPE.RESOURCE: {
-			const children = (catalogue.children || [])
-				.map((child) => transformCatalogueToTree(child, source))
-				.filter(Boolean) as TreeNodeModel[];
-
-			const catalogueType = folderType.includes(catalogue.type)
-				? FileTypes.Folder
-				: FileTypes.File;
-
-			const fileType = isRootFolder ? FileTypes.RootFolder : catalogueType;
-
-			return new TreeNodeModel({
-				// prevent same id between folder and file
-				id: catalogue.id,
-				name: catalogue.name,
-				location: catalogue.name,
-				fileType,
-				icon: fileIcon(catalogue.resourceType, source),
-				isLeaf: fileType === FileTypes.File,
-				data: catalogue,
-				children,
-			});
-		}
-		case CATELOGUE_TYPE.TASK: {
-			const children = (catalogue.children || [])
-				.map((child) => transformCatalogueToTree(child, source))
-				.filter(Boolean) as TreeNodeModel[];
-
-			const catalogueType = folderType.includes(catalogue.type)
-				? FileTypes.Folder
-				: FileTypes.File;
-
-			const fileType = isRootFolder ? FileTypes.RootFolder : catalogueType;
-
-			// If the node already stored in folderTree, then use it
-			const prevNode = molecule.folderTree.get(
-				fileType === FileTypes.File ? catalogue.id : `${catalogue.id}-folder`,
-			);
-
-			// file always generate the new one
-			if (prevNode && fileType !== FileTypes.File) {
-				return new TreeNodeModel({
-					id: prevNode.id,
-					name: prevNode.name,
-					location: prevNode.location,
-					fileType: prevNode.fileType,
-					icon: prevNode.icon,
-					isLeaf: prevNode.isLeaf,
-					data: catalogue,
-					children: children.map((cNode) => {
-						// change the locations to like 「root/abc」 so that render breadcrumbs correctly
-						// eslint-disable-next-line no-param-reassign
-						cNode.location = `${prevNode.location}/${cNode.location}`;
-						return cNode;
-					}),
-				});
-			}
-
-			return new TreeNodeModel({
-				// prevent same id between folder and file
-				id: fileType === FileTypes.File ? catalogue.id : `${catalogue.id}-folder`,
-				name: catalogue.name,
-				location: catalogue.name,
-				fileType,
-				icon: fileIcon(catalogue.taskType, source),
-				isLeaf: fileType === FileTypes.File,
-				data: catalogue,
-				children,
-			});
-		}
-		case CATELOGUE_TYPE.FUNCTION: {
-			const { id, type, name } = catalogue;
-			const children = (catalogue.children || [])
-				// there is a system function in the children node of root folder, we'd better to filter it
-				.filter((child) => !isRootFolder || child.name !== '系统函数')
-				.map((child) => transformCatalogueToTree(child, source))
-				.filter(Boolean) as TreeNodeModel[];
-
-			const catalogueType = folderType.includes(type) ? FileTypes.Folder : FileTypes.File;
-
-			const fileType = isRootFolder ? FileTypes.RootFolder : catalogueType;
-
-			// Because of the same id in different levels, so we should set another uniq id for each tree node
-			return new TreeNodeModel({
-				id: `${id}-${folderType.includes(type) ? 'folder' : 'file'}`,
-				name,
-				location: name,
-				fileType,
-				isLeaf: fileType === FileTypes.File,
-				data: catalogue,
-				icon: fileIcon(catalogue.taskType, source),
-				children,
-			});
-		}
-
-		default:
-			return undefined;
-	}
-}
-
-/**
- * Get the children data in node and save it into Service
- * @param node
- * @param source
- */
-export async function loadTreeNode(
-	node: Partial<CatalogueDataProps>,
-	source: CATELOGUE_TYPE,
-): Promise<TreeNodeModel | null> {
-	const data = await getCatalogueViaNode(node);
-	const nextNode = transformCatalogueToTree(data, source);
-	if (!nextNode) {
-		message.error('load tree node failed');
-		return null;
-	}
-	switch (source) {
-		case 'task': {
-			molecule.folderTree.update(nextNode);
-			break;
-		}
-		case 'resource':
-			resourceManagerTree.update(nextNode);
-			break;
-		case 'function':
-			functionManagerService.update(nextNode);
-			break;
-		default:
-			break;
-	}
-	return nextNode;
 }
 
 /**


### PR DESCRIPTION
### 简介
- 修复目录树重命名的问题
- 修复面包屑在重命名后没有更新的问题
- 修复数据同步任务点击保存没有更新 tab 状态的问题

### 主要变更
- 抽离一个 catalogueService 把全局对目录树的操作都收敛到该 service 中
- 抽离一个 breadcrumbService 把全局对面包屑组件数据的生成操作都收敛
- 暂时移除重命名的 contextMenu，目前重命名仅支持编辑打开 tab 进行修改

### 遗留问题
- [ ] 目录树名称过长 https://github.com/DTStack/molecule/issues/743
- [ ] 重命名的输入框问题 https://github.com/DTStack/molecule/issues/744
- [ ] 编辑器 tab 选中项和目录树选中项未联动 https://github.com/DTStack/molecule/issues/747