### PR TITLE
fix: support abort request in dataSync

### DIFF
--- a/taier-ui/.umirc.ts
+++ b/taier-ui/.umirc.ts
@@ -30,6 +30,9 @@ export default defineConfig({
 		memo.entry('sparksql.worker').add(
 			'monaco-sql-languages/out/esm/sparksql/sparksql.worker.js',
 		);
+		memo.entry('sql.worker').add(
+			'monaco-sql-languages/out/esm/sql/sql.worker.js',
+		);
 		memo.entry('hivesql.worker').add('monaco-sql-languages/out/esm/hivesql/hivesql.worker.js');
 		memo.entry('mysql.worker').add('monaco-sql-languages/out/esm/mysql/mysql.worker.js');
 		memo.entry('flinksql.worker').add(

--- a/taier-ui/src/api/http.ts
+++ b/taier-ui/src/api/http.ts
@@ -20,10 +20,7 @@ import 'whatwg-fetch';
 import { message } from 'antd';
 import ProgressBar from '@/components/progressBar';
 import notification from '@/components/notification';
-import { IResponseBodyProps } from '@/interface';
-
-const controller = new AbortController();
-const { signal } = controller;
+import type { IResponseBodyProps } from '@/interface';
 
 class Http {
 	get<T = any>(url: any, params: any, config: Record<string, any> = {}) {
@@ -68,7 +65,7 @@ class Http {
 
 	request<T = any>(url: string, options: RequestInit) {
 		ProgressBar.show();
-		return fetch(url, { ...options, credentials: 'same-origin', signal })
+		return fetch(url, { ...options, credentials: 'same-origin' })
 			.then((response) => {
 				setTimeout(() => {
 					ProgressBar.hide();

--- a/taier-ui/src/api/index.ts
+++ b/taier-ui/src/api/index.ts
@@ -299,9 +299,9 @@ export default {
 		// 停止执行SQL
 		return http.post(req.STOP_DATA_SYNC_IMMEDIATELY, params);
 	},
-	getIncrementColumns(params: any) {
+	getIncrementColumns(params: any, config?: any) {
 		// 获取增量字段
-		return http.post(req.GET_INCREMENT_COLUMNS, params);
+		return http.post(req.GET_INCREMENT_COLUMNS, params, config);
 	},
 	getHivePartitions(params: any) {
 		// 获取Hive分区
@@ -448,23 +448,23 @@ export default {
 	getTaskJobWorkflowNodes(params: any) {
 		return http.post(req.GET_TASK_JOB_WORKFLOW_NODES, params);
 	},
-	getOfflineTableList(params: any) {
-		return http.post(req.TABLE_LIST, params);
+	getOfflineTableList(params: any, config?: any) {
+		return http.post(req.TABLE_LIST, params, config);
 	},
-	getOfflineTableColumn(params: any) {
-		return http.post(req.GET_TABLE_COLUMN, params);
+	getOfflineTableColumn(params: any, config?: any) {
+		return http.post(req.GET_TABLE_COLUMN, params, config);
 	},
-	getOfflineColumnForSyncopate(params: any) {
-		return http.post(req.GET_COLUMN_FOR_SYNCOPATE, params);
+	getOfflineColumnForSyncopate(params: any, config?: any) {
+		return http.post(req.GET_COLUMN_FOR_SYNCOPATE, params, config);
 	},
-	getHivePartitionsForDataSource(params: any) {
-		return http.post(req.GET_HIVE_PARTITIONS, params);
+	getHivePartitionsForDataSource(params: any, config?: any) {
+		return http.post(req.GET_HIVE_PARTITIONS, params, config);
 	},
 	getDataSourcePreview(params: any) {
 		return http.post(req.GET_DATA_SOURCE_PREVIEW, params);
 	},
-	getAllSchemas(params: any) {
-		return http.post(req.GET_ALL_SCHEMAS, params);
+	getAllSchemas(params: any, config?: any) {
+		return http.post(req.GET_ALL_SCHEMAS, params, config);
 	},
 	queryByTenantId<T>(params: any) {
 		return http.get<T>(req.QUREY_BY_TENANT_ID, params);

--- a/taier-ui/src/extensions/languages/index.tsx
+++ b/taier-ui/src/extensions/languages/index.tsx
@@ -125,9 +125,11 @@ function registerWorkers() {
 				case TASK_LANGUAGE.JSON: {
 					return './json.worker.js';
 				}
-				case TASK_LANGUAGE.SQL:
-				default: {
+				case TASK_LANGUAGE.SQL: {
 					return './sql.worker.js';
+				}
+				default: {
+					return './editor.worker.js';
 				}
 			}
 		},

--- a/taier-ui/src/pages/editor/dataSync/keymap.tsx
+++ b/taier-ui/src/pages/editor/dataSync/keymap.tsx
@@ -181,6 +181,7 @@ export default function KeyMap({
 		source: [],
 		target: [],
 	});
+	const abortController = useRef(new AbortController());
 	// step 容器
 	const $canvas = useRef<SVGSVGElement>(null);
 	// 拖动的线
@@ -1378,18 +1379,28 @@ export default function KeyMap({
 
 		setLoading(true);
 		Promise.all([
-			Api.getOfflineTableColumn({
-				sourceId: sourceMap.sourceId,
-				schema: sourceSchema,
-				tableName: Array.isArray(sourceTable) ? sourceTable[0] : sourceTable,
-				isIncludePart: sourcePart,
-			}),
-			Api.getOfflineTableColumn({
-				sourceId: targetMap.sourceId,
-				schema: targetSchema,
-				tableName: targetTable,
-				isIncludePart: targetPart,
-			}),
+			Api.getOfflineTableColumn(
+				{
+					sourceId: sourceMap.sourceId,
+					schema: sourceSchema,
+					tableName: Array.isArray(sourceTable) ? sourceTable[0] : sourceTable,
+					isIncludePart: sourcePart,
+				},
+				{
+					signal: abortController.current.signal,
+				},
+			),
+			Api.getOfflineTableColumn(
+				{
+					sourceId: targetMap.sourceId,
+					schema: targetSchema,
+					tableName: targetTable,
+					isIncludePart: targetPart,
+				},
+				{
+					signal: abortController.current.signal,
+				},
+			),
 		])
 			.then((results) => {
 				if (results.every((res) => res.code === 1)) {
@@ -1423,6 +1434,10 @@ export default function KeyMap({
 
 	useEffect(() => {
 		getTableCols();
+
+		return () => {
+			abortController.current.abort();
+		};
 	}, []);
 
 	useEffect(() => {


### PR DESCRIPTION
### 简介
- 数据同步任务支持中断请求
- 优化异步渲染

### 主要变更
- 新增 sql.worker.js 
- 数据同步任务的接口有时候需要查询很久，用户关闭数据同步任务的 tab 后仍然在 pending 请求，会导致其他请求挂起，所以需要在关闭数据同步任务后把 pending 的请求 cancel 了
- 通过 lazy 和 suspend 组件优化组件的异步渲染