### PR TITLE
[fix_1.2][taier-ui]: fix window Ctrl split #555

### DIFF
--- a/taier-ui/src/components/editorEntry/index.tsx
+++ b/taier-ui/src/components/editorEntry/index.tsx
@@ -18,8 +18,9 @@
 
 import { useEffect, useState } from 'react';
 import { KeybindingHelper } from '@dtinsight/molecule/esm/services/keybinding';
-import './index.scss';
 import { Utils } from '@dtinsight/dt-utils/lib';
+import './index.scss';
+
 
 const commands = [
 	{ id: 'sidebar', label: '切换侧边栏' },

--- a/taier-ui/src/components/editorEntry/index.tsx
+++ b/taier-ui/src/components/editorEntry/index.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useState } from 'react';
 import { KeybindingHelper } from '@dtinsight/molecule/esm/services/keybinding';
 import './index.scss';
+import { Utils } from '@dtinsight/dt-utils/lib';
 
 const commands = [
 	{ id: 'sidebar', label: '切换侧边栏' },
@@ -55,7 +56,7 @@ export default function EditorEntry() {
 						<div className="label">{key.label}</div>
 						<div className="keybindings">
 							{key.keybindings
-								.split('')
+								.split(Utils.isMacOs() ? '' : '+')
 								.filter(Boolean)
 								.map((keyCode) => (
 									<code key={keyCode} className="keyCode">{keyCode}</code>


### PR DESCRIPTION
产生问题： window 的keybindings出现“Ctril”进行split，导致分割符展示；
修复： 通过正则匹配，如果匹配到，将Ctril字段提取出来，剩下的字符串进行split


### Related Issues
Closed #555 