### PR TITLE
[hotfix_871][taier-worker-plugin] script-core build Dir is error

### DIFF
--- a/taier-worker/taier-worker-plugin/script/yarn2-hdfs2-script/script-core/pom.xml
+++ b/taier-worker/taier-worker-plugin/script/yarn2-hdfs2-script/script-core/pom.xml
@@ -175,10 +175,10 @@
                             <tasks>
                                 <copy file="${basedir}/target/${artifactId}-${project.version}.jar"
                                       tofile="${basedir}/target/script-core-script.jar"/>
-                                <copy todir="${basedir}/target/../../../../worker-plugins/${plugin.dir.name}/"
+                                <copy todir="${basedir}/target/../../../../../../worker-plugins/${plugin.dir.name}/"
                                       file="${basedir}/target/script-core-script.jar"/>
                                 <delete>
-                                    <fileset dir="${basedir}/target/../../../../worker-plugins/${plugin.dir.name}/"
+                                    <fileset dir="${basedir}/target/../../../../../../worker-plugins/${plugin.dir.name}/"
                                              includes="${jar.name}-*.jar"
                                              excludes="script-core-script.jar"/>
                                 </delete>

--- a/taier-worker/taier-worker-plugin/script/yarn3-hdfs3-script/script-core/pom.xml
+++ b/taier-worker/taier-worker-plugin/script/yarn3-hdfs3-script/script-core/pom.xml
@@ -173,10 +173,10 @@
                             <tasks>
                                 <copy file="${basedir}/target/${artifactId}-${project.version}.jar"
                                       tofile="${basedir}/target/script-core-script.jar" />
-                                <copy todir="${basedir}/target/../../../../worker-plugins/${plugin.dir.name}/"
+                                <copy todir="${basedir}/target/../../../../../../worker-plugins/${plugin.dir.name}/"
                                       file="${basedir}/target/script-core-script.jar"/>
                                 <delete>
-                                    <fileset dir="${basedir}/target/../../../../worker-plugins/${plugin.dir.name}/"
+                                    <fileset dir="${basedir}/target/../../../../../../worker-plugins/${plugin.dir.name}/"
                                              includes="${jar.name}-*.jar"
                                              excludes="script-core-script.jar"/>
                                 </delete>


### PR DESCRIPTION
修复script 插件构建时，script-core的jar 位置错位问题

