### PR TITLE
fix(sec): upgrade ch.qos.logback:logback-classic to 1.2.0

### DIFF
--- a/taier-worker/taier-worker-api/pom.xml
+++ b/taier-worker/taier-worker-api/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
+            <version>1.2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ch.qos.logback:logback-classic 1.1.7
- [CVE-2017-5929](https://www.oscs1024.com/hd/CVE-2017-5929)


### What did I do？
Upgrade ch.qos.logback:logback-classic from 1.1.7 to 1.2.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS