### PR TITLE
fixed: ftp target index #938 no initial value given

### DIFF
--- a/taier-data-develop/src/main/java/com/dtstack/taier/develop/service/develop/impl/DevelopTaskService.java
+++ b/taier-data-develop/src/main/java/com/dtstack/taier/develop/service/develop/impl/DevelopTaskService.java
@@ -1447,11 +1447,11 @@ public class DevelopTaskService extends ServiceImpl<DevelopTaskMapper, Task> {
             for (int i = 0; i < lastCellNum; i++) {
                 FTPColumn ftpColumn = new FTPColumn();
                 if (!payload.getFirstColumnName()) {
-                    ftpColumn.setName("column" + i);
+                    ftpColumn.setKey("column" + i);
                 } else {
                     Cell cell = titleRow.getCell(i, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
                     String titleValue = cell.getStringCellValue();
-                    ftpColumn.setName(titleValue);
+                    ftpColumn.setKey(titleValue);
                 }
                 ftpColumn.setType("string");
                 ftpColumn.setIndex(i);
@@ -1486,7 +1486,7 @@ public class DevelopTaskService extends ServiceImpl<DevelopTaskMapper, Task> {
                 if (payload.getFirstColumnName() && limit == 1) {
                     for (int i = 0; i < split.length; i++) {
                         FTPColumn ftpColumn = new FTPColumn();
-                        ftpColumn.setName(split[i]);
+                        ftpColumn.setKey(split[i]);
                         ftpColumn.setType("string");
                         ftpColumn.setIndex(i);
                         columns.add(ftpColumn);
@@ -1494,7 +1494,7 @@ public class DevelopTaskService extends ServiceImpl<DevelopTaskMapper, Task> {
                 } else if (!payload.getFirstColumnName() && limit == 1) {
                     for (int i = 0; i < split.length; i++) {
                         FTPColumn ftpColumn = new FTPColumn();
-                        ftpColumn.setName("column" + i);
+                        ftpColumn.setKey("column" + i);
                         ftpColumn.setType("string");
                         ftpColumn.setIndex(i);
                         columns.add(ftpColumn);

--- a/taier-data-develop/src/main/java/com/dtstack/taier/develop/service/template/ftp/FTPColumn.java
+++ b/taier-data-develop/src/main/java/com/dtstack/taier/develop/service/template/ftp/FTPColumn.java
@@ -38,7 +38,7 @@ public class FTPColumn {
     /**
      * column name
      */
-    private String name;
+    private String key;
 
     public Integer getIndex() {
         return index;
@@ -56,12 +56,12 @@ public class FTPColumn {
         this.type = type;
     }
 
-    public String getName() {
-        return name;
+    public String getKey() {
+        return key;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public void setKey(String key) {
+        this.key = key;
     }
 
     @Override
@@ -69,7 +69,7 @@ public class FTPColumn {
         return "FtpColumn{" +
                 "index=" + index +
                 ", type='" + type + '\'' +
-                ", name='" + name + '\'' +
+                ", name='" + key + '\'' +
                 '}';
     }
 }

--- a/taier-data-develop/src/main/java/com/dtstack/taier/develop/service/template/ftp/FTPWriteParam.java
+++ b/taier-data-develop/src/main/java/com/dtstack/taier/develop/service/template/ftp/FTPWriteParam.java
@@ -19,10 +19,12 @@
 package com.dtstack.taier.develop.service.template.ftp;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.dtstack.taier.develop.common.template.Writer;
 import com.dtstack.taier.develop.enums.develop.EWriterMode;
 import com.dtstack.taier.develop.service.template.PluginName;
+import org.apache.commons.collections.CollectionUtils;
 
 import java.util.List;
 
@@ -63,6 +65,9 @@ public class FTPWriteParam extends FTPParam implements Writer {
             param = JSON.parseObject(JSON.toJSON(this).toString());
         }
 
+        // reset column index
+        param.put("column", resetColumnIndex(param.getJSONArray("column")));
+
         if (resetWriteMode()) {
             // 前端传入是 replace 和 insert
             param.put("writeMode", EWriterMode
@@ -76,6 +81,23 @@ public class FTPWriteParam extends FTPParam implements Writer {
         res.put("name", pluginName());
         res.put("parameter", param);
         return res;
+    }
+
+    /**
+     * reset column index
+     * @param jsonColumns request parameter target column of the json text
+     * @return list of converted entity objects
+     */
+    private List<FTPColumn> resetColumnIndex(JSONArray jsonColumns) {
+        // transfer to entity
+        List<FTPColumn> columns = JSONObject.parseArray(JSONObject.toJSONString(jsonColumns), FTPColumn.class);
+        if (CollectionUtils.isNotEmpty(columns)) {
+            int index = 0;
+            for (FTPColumn column : columns) {
+                column.setIndex(index++);
+            }
+        }
+        return columns;
     }
 
     @Override


### PR DESCRIPTION
### Change Logs

#### API Change

- API response result changes of the `/taier/api/task/parsing_ftp_columns`

  ```
  {
    "code": 1,
    "message": null,
    "data": {
      "column": [
        {
          "index": 2,
          "type": "string",
           -- "name": "column2"
           ++ "key": "column2"
        }
      ],
      "filetype": "TXT"
    },
    "space": 0,
    "success": true,
    "version": null
  }
  ```

#### Feature Change

- Add writer's field index autofill