### PR TITLE
[issue_1144][tail-ui] restrict dt-sql-parser's version

### DIFF
--- a/taier-ui/package.json
+++ b/taier-ui/package.json
@@ -99,5 +99,8 @@
 		"typescript": "4.7.4",
 		"umi-plugin-tailwindcss": "^3.2.1",
 		"yorkie": "^2.0.0"
+	},
+	"resolutions": {
+		"dt-sql-parser": "4.0.0-beta.3.2"
 	}
 }


### PR DESCRIPTION
## 简介
dt-sql-parser发布了最新版本，generic更名为mysql，导致文件找不到，故限制dt-sql-parser版本

## 🔗 相关 Issue
fix https://github.com/DTStack/Taier/issues/1144