### PR TITLE
[issue_1160][docker] Fixed name error when using docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,10 @@ services:
       TZ: Asia/Shanghai
     ports:
       - 3306:3306
+    container_name: taier-db
   taier-zk:
     image: zookeeper:3.4.9
+    container_name: taier-zk
   taier:
     image: dtopensource/taier:latest
     environment:
@@ -22,3 +24,4 @@ services:
       TZ: Asia/Shanghai
     ports:
       - 8090:8090
+    container_name: taier


### PR DESCRIPTION
Use docker-compose syntax to explicitly specify the name of the container after it is started to avoid container name format errors when docker-compose is repeatedly executed.

check it #1160 